### PR TITLE
Convert calldown form to Tailwind and modernize UI

### DIFF
--- a/public/form.html
+++ b/public/form.html
@@ -89,67 +89,12 @@
         class="absolute inset-x-0 top-0 -z-10 h-48 bg-gradient-to-b from-skyhawk-500/10 to-transparent blur-3xl dark:h-72"
       ></div>
 
-      <main class="mx-auto flex min-h-screen max-w-6xl flex-col px-4 py-5 sm:px-6 sm:py-6 lg:px-8">
-        <div class="mx-auto mb-4 w-full max-w-4xl">
-          <div
-            class="rounded-[1.75rem] border border-slate-200/80 bg-white/85 p-4 shadow-xl shadow-skyhawk-100/60 backdrop-blur-xl dark:border-white/10 dark:bg-white/10 dark:shadow-glow sm:p-5"
-          >
-            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div class="min-w-0">
-                <p
-                  class="mb-2 inline-flex items-center rounded-full border border-skyhawk-200 bg-skyhawk-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-skyhawk-700 dark:border-skyhawk-300/20 dark:bg-skyhawk-400/10 dark:text-skyhawk-100"
-                >
-                  Skyhawk Composite Squadron
-                </p>
-                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-                  <h1
-                    class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white sm:text-[1.85rem]"
-                  >
-                    Weekly cadet response form
-                  </h1>
-                  <span
-                    class="inline-flex w-fit items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-200"
-                  >
-                    Fast two-step check-in
-                  </span>
-                </div>
-                <p
-                  class="mt-2 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-[0.95rem]"
-                >
-                  Tell staff whether you are coming, then finish the matching second step.
-                </p>
-              </div>
-
-              <div
-                class="grid gap-2 rounded-2xl border border-slate-200 bg-slate-50/90 px-4 py-3 text-sm text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-950/40 dark:text-slate-300 sm:grid-cols-2 sm:items-center sm:gap-3"
-              >
-                <div>
-                  <p
-                    class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400"
-                  >
-                    Deadline
-                  </p>
-                  <p class="mt-1 font-semibold text-slate-900 dark:text-slate-100">
-                    Sunday at 22:00
-                  </p>
-                </div>
-                <div class="hidden h-10 w-px bg-slate-200 dark:bg-white/10 sm:block"></div>
-                <div>
-                  <p
-                    class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400"
-                  >
-                    Why it matters
-                  </p>
-                  <p class="mt-1 leading-5">Helps staff plan attendance, testing, and logistics.</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
+      <main
+        class="mx-auto flex min-h-screen max-w-6xl flex-col justify-center px-4 py-5 sm:px-6 sm:py-6 lg:px-8"
+      >
         <form
           id="cadetForm"
-          class="mx-auto w-full max-w-4xl rounded-[1.75rem] border border-slate-200/80 bg-white/92 p-5 text-slate-900 shadow-xl shadow-skyhawk-100/70 ring-1 ring-white/60 backdrop-blur sm:p-7 lg:p-8 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:shadow-glow dark:ring-white/10"
+          class="mx-auto w-full max-w-4xl rounded-[1.75rem] border-2 border-skyhawk-200/90 bg-white/96 p-5 text-slate-900 shadow-[0_24px_80px_rgba(94,132,175,0.16)] ring-1 ring-white/70 backdrop-blur sm:p-7 lg:p-8 dark:border-skyhawk-500/30 dark:bg-slate-900/88 dark:text-slate-100 dark:shadow-glow dark:ring-white/10"
         >
           <div id="formContainer"></div>
         </form>
@@ -296,7 +241,7 @@
           "min-h-screen bg-transparent text-slate-900 antialiased dark:text-slate-100";
         const formShell = document.getElementById("cadetForm");
         formShell.className =
-          "mx-auto w-full max-w-4xl rounded-[1.75rem] border border-slate-200/80 bg-white/90 p-5 text-slate-900 shadow-none ring-1 ring-white/60 backdrop-blur-xl dark:border-white/20 dark:bg-slate-950/65 dark:text-white dark:ring-white/20 sm:p-7 lg:p-8";
+          "mx-auto w-full max-w-4xl rounded-[1.5rem] border-0 bg-transparent p-3 text-slate-900 shadow-none ring-0 backdrop-blur-none dark:text-white sm:p-4 lg:p-5";
       }
 
       function isFormClosed() {
@@ -376,7 +321,7 @@
                     <h2 class="mt-2 text-2xl font-semibold tracking-tight text-slate-900 dark:text-white sm:text-[2rem]">${section.title}</h2>
                   </div>
                   <div class="rounded-2xl border border-skyhawk-100 bg-skyhawk-50 px-4 py-3 text-sm text-skyhawk-700 shadow-sm dark:border-skyhawk-400/20 dark:bg-skyhawk-500/10 dark:text-skyhawk-100">
-                    ${section.step === 1 ? "Choose whether you are attending to unlock step two." : "Final step — review and send your response."}
+                    Deadline: Sunday at 22:00
                   </div>
                 </div>
                 <div>
@@ -483,7 +428,7 @@
             el = document.createElement("div");
             el.className = "relative";
             control = document.createElement("select");
-            control.className = `${classListString(inputBaseClasses)} pr-12 font-medium`;
+            control.className = `${classListString(inputBaseClasses)} pr-14 font-medium border-2 bg-white shadow-[0_12px_32px_rgba(15,23,42,0.06)] dark:bg-slate-900`;
             const selectPlaceholder = document.createElement("option");
             selectPlaceholder.value = "";
             selectPlaceholder.textContent = "Pick one…";
@@ -497,10 +442,12 @@
             el.appendChild(control);
             el.insertAdjacentHTML(
               "beforeend",
-              `<span class="pointer-events-none absolute inset-y-0 right-4 flex items-center text-slate-400 dark:text-slate-500">
+              `<span class="pointer-events-none absolute inset-y-0 right-3 flex items-center">
+                <span class="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-skyhawk-50 text-skyhawk-600 shadow-sm dark:bg-skyhawk-500/10 dark:text-skyhawk-200">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
                   <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.51a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
                 </svg>
+                </span>
               </span>`
             );
             break;
@@ -532,7 +479,7 @@
               radioLabel.innerHTML = `
                 <span>${opt}</span>
                 <span data-radio-dot class="inline-flex h-5 w-5 items-center justify-center rounded-full border-2 border-slate-300 bg-white transition dark:border-slate-500 dark:bg-slate-950">
-                  <span data-radio-dot-inner class="h-2.5 w-2.5 scale-0 rounded-full bg-transparent transition"></span>
+                  <span data-radio-dot-inner class="h-2.5 w-2.5 rounded-full bg-transparent opacity-0"></span>
                 </span>
               `;
 
@@ -582,9 +529,8 @@
           dot.classList.toggle("bg-skyhawk-500", radio.checked);
           dot.classList.toggle("dark:border-skyhawk-400", radio.checked);
           dot.classList.toggle("dark:bg-skyhawk-400", radio.checked);
-          innerDot.classList.toggle("bg-white", radio.checked);
-          innerDot.classList.toggle("scale-100", radio.checked);
-          innerDot.classList.toggle("scale-0", !radio.checked);
+          innerDot.style.backgroundColor = radio.checked ? "#ffffff" : "transparent";
+          innerDot.style.opacity = radio.checked ? "1" : "0";
         });
       }
 

--- a/public/form.html
+++ b/public/form.html
@@ -432,11 +432,8 @@
             break;
 
           case "select": {
-            el = document.createElement("div");
-            el.className =
-              "relative overflow-hidden rounded-[1.35rem] border-2 border-slate-200 bg-white shadow-[0_12px_32px_rgba(15,23,42,0.06)] dark:border-slate-700 dark:bg-slate-900";
             control = document.createElement("select");
-            control.className = `${classListString(inputBaseClasses)} mt-0 rounded-[1.25rem] border-0 bg-transparent pr-16 shadow-none`;
+            control.className = `${classListString(inputBaseClasses)} appearance-auto border-2 bg-white pr-4 dark:bg-slate-900`;
             const selectPlaceholder = document.createElement("option");
             selectPlaceholder.value = "";
             selectPlaceholder.textContent = "Pick one…";
@@ -447,17 +444,7 @@
               option.textContent = opt;
               control.appendChild(option);
             });
-            el.appendChild(control);
-            el.insertAdjacentHTML(
-              "beforeend",
-              `<span class="pointer-events-none absolute inset-y-1.5 right-1.5 flex items-center">
-                <span class="inline-flex h-full min-h-11 w-11 items-center justify-center rounded-[1rem] border border-skyhawk-100 bg-skyhawk-50 text-skyhawk-600 shadow-sm dark:border-skyhawk-400/20 dark:bg-skyhawk-500/10 dark:text-skyhawk-200">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
-                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.51a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
-                </svg>
-                </span>
-              </span>`
-            );
+            el = control;
             break;
           }
 

--- a/public/form.html
+++ b/public/form.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en-US">
+<html lang="en-US" class="bg-slate-50">
   <head>
     <title>Cadet Calldown Form</title>
     <link rel="icon" type="image/png" href="/media/website/skyhawks_logo_CAP_transparent.ico" />
@@ -47,6 +47,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
+        darkMode: "class",
         theme: {
           extend: {
             colors: {
@@ -70,51 +71,77 @@
         }
       };
     </script>
+    <script>
+      const storedTheme = localStorage.getItem("theme") || "light";
+      if (storedTheme === "dark") {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
   </head>
-  <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
+  <body
+    class="min-h-screen bg-slate-50 text-slate-900 antialiased transition-colors duration-200 dark:bg-slate-950 dark:text-slate-100"
+  >
     <div class="relative isolate overflow-hidden">
       <div
-        class="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(96,165,250,0.16),_transparent_30%),radial-gradient(circle_at_bottom_right,_rgba(14,165,233,0.14),_transparent_28%),linear-gradient(180deg,_#020617_0%,_#0f172a_45%,_#111827_100%)]"
+        class="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(96,165,250,0.16),_transparent_26%),radial-gradient(circle_at_bottom_right,_rgba(14,165,233,0.12),_transparent_26%),linear-gradient(180deg,_#f8fafc_0%,_#eef4fb_42%,_#f8fafc_100%)] dark:bg-[radial-gradient(circle_at_top,_rgba(96,165,250,0.16),_transparent_30%),radial-gradient(circle_at_bottom_right,_rgba(14,165,233,0.14),_transparent_28%),linear-gradient(180deg,_#020617_0%,_#0f172a_45%,_#111827_100%)]"
       ></div>
       <div
-        class="absolute inset-x-0 top-0 -z-10 h-72 bg-gradient-to-b from-skyhawk-500/10 to-transparent blur-3xl"
+        class="absolute inset-x-0 top-0 -z-10 h-48 bg-gradient-to-b from-skyhawk-500/10 to-transparent blur-3xl dark:h-72"
       ></div>
 
-      <main class="mx-auto flex min-h-screen max-w-6xl flex-col px-4 py-8 sm:px-6 lg:px-8 lg:py-12">
-        <div class="mx-auto mb-8 w-full max-w-4xl">
+      <main class="mx-auto flex min-h-screen max-w-6xl flex-col px-4 py-5 sm:px-6 sm:py-6 lg:px-8">
+        <div class="mx-auto mb-4 w-full max-w-4xl">
           <div
-            class="rounded-[2rem] border border-white/10 bg-white/5 p-6 shadow-glow backdrop-blur-xl sm:p-8"
+            class="rounded-[1.75rem] border border-slate-200/80 bg-white/85 p-4 shadow-xl shadow-skyhawk-100/60 backdrop-blur-xl dark:border-white/10 dark:bg-white/10 dark:shadow-glow sm:p-5"
           >
-            <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-              <div class="max-w-2xl">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div class="min-w-0">
                 <p
-                  class="mb-3 inline-flex items-center rounded-full border border-skyhawk-300/20 bg-skyhawk-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-skyhawk-100"
+                  class="mb-2 inline-flex items-center rounded-full border border-skyhawk-200 bg-skyhawk-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-skyhawk-700 dark:border-skyhawk-300/20 dark:bg-skyhawk-400/10 dark:text-skyhawk-100"
                 >
                   Skyhawk Composite Squadron
                 </p>
-                <h1 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
-                  Weekly cadet response form
-                </h1>
-                <p class="mt-4 max-w-2xl text-sm leading-6 text-slate-300 sm:text-base">
-                  Confirm attendance, drill testing, and any notes for the next meeting using a
-                  cleaner, faster workflow built for mobile and desktop.
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                  <h1
+                    class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white sm:text-[1.85rem]"
+                  >
+                    Weekly cadet response form
+                  </h1>
+                  <span
+                    class="inline-flex w-fit items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-200"
+                  >
+                    Fast two-step check-in
+                  </span>
+                </div>
+                <p
+                  class="mt-2 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-[0.95rem]"
+                >
+                  Tell staff whether you are coming, then finish the matching second step.
                 </p>
               </div>
 
               <div
-                class="grid gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-sm text-slate-300 sm:min-w-64"
+                class="grid gap-2 rounded-2xl border border-slate-200 bg-slate-50/90 px-4 py-3 text-sm text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-950/40 dark:text-slate-300 sm:grid-cols-2 sm:items-center sm:gap-3"
               >
                 <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-                    Weekly reminder
+                  <p
+                    class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400"
+                  >
+                    Deadline
                   </p>
-                  <p class="mt-1 font-medium text-slate-100">Submit before Sunday at 22:00</p>
+                  <p class="mt-1 font-semibold text-slate-900 dark:text-slate-100">
+                    Sunday at 22:00
+                  </p>
                 </div>
-                <div class="h-px bg-white/10"></div>
-                <p class="leading-6 text-slate-400">
-                  Responses help staff prepare attendance, drill tests, and logistics before the
-                  next meeting.
-                </p>
+                <div class="hidden h-10 w-px bg-slate-200 dark:bg-white/10 sm:block"></div>
+                <div>
+                  <p
+                    class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400"
+                  >
+                    Why it matters
+                  </p>
+                  <p class="mt-1 leading-5">Helps staff plan attendance, testing, and logistics.</p>
+                </div>
               </div>
             </div>
           </div>
@@ -122,23 +149,23 @@
 
         <form
           id="cadetForm"
-          class="mx-auto w-full max-w-4xl rounded-[2rem] border border-white/10 bg-white/95 p-5 text-slate-900 shadow-glow ring-1 ring-white/10 backdrop-blur sm:p-8 lg:p-10"
+          class="mx-auto w-full max-w-4xl rounded-[1.75rem] border border-slate-200/80 bg-white/92 p-5 text-slate-900 shadow-xl shadow-skyhawk-100/70 ring-1 ring-white/60 backdrop-blur sm:p-7 lg:p-8 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:shadow-glow dark:ring-white/10"
         >
           <div id="formContainer"></div>
         </form>
 
         <div
           id="closedMessage"
-          class="mx-auto hidden w-full max-w-4xl rounded-[2rem] border border-amber-300/20 bg-white/95 p-6 text-center text-slate-900 shadow-glow ring-1 ring-amber-200/40 backdrop-blur sm:p-10"
+          class="mx-auto hidden w-full max-w-4xl rounded-[1.75rem] border border-amber-300/40 bg-white/95 p-6 text-center text-slate-900 shadow-xl shadow-amber-100/60 ring-1 ring-amber-200/50 backdrop-blur dark:border-amber-300/20 dark:bg-slate-900/90 dark:text-slate-100 dark:shadow-none dark:ring-white/10 sm:p-10"
         >
           <div
-            class="mx-auto inline-flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-100 text-amber-600 shadow-lg shadow-amber-200/60"
+            class="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-100 text-amber-600 shadow-lg shadow-amber-200/60 dark:bg-amber-400/15 dark:text-amber-200 dark:shadow-none"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="currentColor"
-              class="h-8 w-8"
+              class="h-7 w-7"
             >
               <path
                 fill-rule="evenodd"
@@ -147,23 +174,25 @@
               />
             </svg>
           </div>
-          <h2 class="mt-6 text-3xl font-semibold tracking-tight text-slate-900">Form Closed</h2>
-          <p class="mt-3 text-base leading-7 text-slate-600 sm:text-lg">
+          <h2 class="mt-5 text-3xl font-semibold tracking-tight text-slate-900 dark:text-white">
+            Form Closed
+          </h2>
+          <p class="mt-3 text-base leading-7 text-slate-600 dark:text-slate-300 sm:text-lg">
             This form is currently closed for the week.
           </p>
-          <p class="mt-4 text-sm leading-7 text-slate-500 sm:text-base">
+          <p class="mt-4 text-sm leading-7 text-slate-500 dark:text-slate-400 sm:text-base">
             Please check back later to submit your response for the next meeting. You are still
             welcome to attend the upcoming meeting; drill tests and other submissions must wait
             until next week.
           </p>
-          <p class="mt-4 text-sm leading-7 text-slate-500 sm:text-base">
+          <p class="mt-4 text-sm leading-7 text-slate-500 dark:text-slate-400 sm:text-base">
             Please make sure to submit your response before the cutoff date next week to ensure your
             drill test is scheduled.
           </p>
           <div
-            class="mt-8 inline-flex rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner shadow-slate-200/70"
+            class="mt-8 inline-flex rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner shadow-slate-200/70 dark:border-white/10 dark:bg-slate-950/70 dark:text-slate-200 dark:shadow-none"
           >
-            <span class="font-semibold text-slate-900">Reminder:</span>
+            <span class="font-semibold text-slate-900 dark:text-white">Reminder:</span>
             <span class="ml-2">All responses must be submitted before Sunday at 22:00.</span>
           </div>
         </div>
@@ -183,7 +212,7 @@
         "rounded-2xl",
         "border",
         "border-slate-200",
-        "bg-white",
+        "bg-slate-50/80",
         "px-4",
         "py-3",
         "text-base",
@@ -193,9 +222,16 @@
         "transition",
         "duration-200",
         "placeholder:text-slate-400",
+        "appearance-none",
         "focus:border-skyhawk-500",
         "focus:ring-4",
-        "focus:ring-skyhawk-100"
+        "focus:ring-skyhawk-100",
+        "dark:border-slate-700",
+        "dark:bg-slate-900/80",
+        "dark:text-slate-100",
+        "dark:placeholder:text-slate-500",
+        "dark:focus:border-skyhawk-400",
+        "dark:focus:ring-skyhawk-500/20"
       ];
 
       const fieldWrapperClasses = ["space-y-2"];
@@ -246,15 +282,21 @@
           "hover:bg-slate-50",
           "focus:outline-none",
           "focus:ring-4",
-          "focus:ring-slate-200"
+          "focus:ring-slate-200",
+          "dark:border-slate-700",
+          "dark:bg-slate-900/80",
+          "dark:text-slate-100",
+          "dark:hover:border-slate-600",
+          "dark:hover:bg-slate-800"
         ]
       };
 
       if (window.self !== window.top) {
-        document.body.className = "min-h-screen bg-transparent text-slate-100 antialiased";
+        document.body.className =
+          "min-h-screen bg-transparent text-slate-900 antialiased dark:text-slate-100";
         const formShell = document.getElementById("cadetForm");
         formShell.className =
-          "mx-auto w-full max-w-4xl rounded-[2rem] border border-white/20 bg-white/10 p-5 text-white shadow-none ring-1 ring-white/20 backdrop-blur-xl sm:p-8 lg:p-10";
+          "mx-auto w-full max-w-4xl rounded-[1.75rem] border border-slate-200/80 bg-white/90 p-5 text-slate-900 shadow-none ring-1 ring-white/60 backdrop-blur-xl dark:border-white/20 dark:bg-slate-950/65 dark:text-white dark:ring-white/20 sm:p-7 lg:p-8";
       }
 
       function isFormClosed() {
@@ -312,7 +354,7 @@
       function renderForm() {
         form.innerHTML = "";
 
-        formConfig.sections.forEach((section, index) => {
+        formConfig.sections.forEach((section) => {
           const sec = document.createElement("section");
           sec.dataset.step = section.step;
           sec.className = classListString([
@@ -320,9 +362,10 @@
             ...(section.step === 1 ? sectionClasses.visible : [])
           ]);
 
-          const progressLabel = `Step ${index + 1} of ${formConfig.sections.length}`;
+          const progressStep = section.step === 1 ? 1 : 2;
+          const progressLabel = `Step ${progressStep} of 2`;
           const errorBoxId = `section-${section.step}-error`;
-          const progressWidth = `${((index + 1) / formConfig.sections.length) * 100}%`;
+          const progressWidth = `${progressStep * 50}%`;
 
           sec.innerHTML = `
             <div class="space-y-6">
@@ -330,19 +373,19 @@
                 <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <p class="text-xs font-semibold uppercase tracking-[0.24em] text-skyhawk-600">${progressLabel}</p>
-                    <h2 class="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">${section.title}</h2>
+                    <h2 class="mt-2 text-2xl font-semibold tracking-tight text-slate-900 dark:text-white sm:text-[2rem]">${section.title}</h2>
                   </div>
-                  <div class="rounded-2xl border border-skyhawk-100 bg-skyhawk-50 px-4 py-3 text-sm text-skyhawk-700 shadow-sm">
-                    Complete each section before continuing.
+                  <div class="rounded-2xl border border-skyhawk-100 bg-skyhawk-50 px-4 py-3 text-sm text-skyhawk-700 shadow-sm dark:border-skyhawk-400/20 dark:bg-skyhawk-500/10 dark:text-skyhawk-100">
+                    ${section.step === 1 ? "Choose whether you are attending to unlock step two." : "Final step — review and send your response."}
                   </div>
                 </div>
                 <div>
-                  <div class="h-2 w-full overflow-hidden rounded-full bg-slate-100">
+                  <div class="h-2 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
                     <div class="h-full rounded-full bg-gradient-to-r from-skyhawk-500 via-skyhawk-400 to-cyan-400" style="width: ${progressWidth}"></div>
                   </div>
                 </div>
               </div>
-              <div id="${errorBoxId}" class="hidden rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 shadow-sm" role="alert"></div>
+              <div id="${errorBoxId}" class="hidden rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 shadow-sm dark:border-rose-400/20 dark:bg-rose-500/10 dark:text-rose-100" role="alert"></div>
             </div>
           `;
 
@@ -367,7 +410,7 @@
             nav.appendChild(spacer);
           }
 
-          if (section.step < formConfig.sections.length) {
+          if (section.step === 1) {
             const next = document.createElement("button");
             next.type = "button";
             next.textContent = "Continue";
@@ -390,14 +433,14 @@
         done.dataset.step = formConfig.sections.length + 1;
         done.className = classListString(sectionClasses.base);
         done.innerHTML = `
-          <div class="rounded-[2rem] border border-emerald-200 bg-emerald-50 p-6 shadow-sm sm:p-8">
-            <div class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500 text-white shadow-lg shadow-emerald-200">
+          <div class="rounded-[1.75rem] border border-emerald-200 bg-emerald-50 p-6 shadow-sm dark:border-emerald-400/20 dark:bg-emerald-500/10 sm:p-8">
+            <div class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500 text-white shadow-lg shadow-emerald-200 dark:shadow-none">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-7 w-7">
                 <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-2.53a.75.75 0 1 0-1.22-.88l-3.236 4.486-1.387-1.387a.75.75 0 0 0-1.06 1.06l2.012 2.013a.75.75 0 0 0 1.14-.09l3.75-5.202Z" clip-rule="evenodd" />
               </svg>
             </div>
-            <h2 class="mt-5 text-3xl font-semibold tracking-tight text-emerald-950">Submission complete</h2>
-            <p id="confirmationMessage" class="mt-3 max-w-2xl text-base leading-7 text-emerald-900"></p>
+            <h2 class="mt-5 text-3xl font-semibold tracking-tight text-emerald-950 dark:text-white">Submission complete</h2>
+            <p id="confirmationMessage" class="mt-3 max-w-2xl text-base leading-7 text-emerald-900 dark:text-emerald-50"></p>
           </div>
         `;
         form.appendChild(done);
@@ -410,47 +453,63 @@
         const fieldId = `field-${sectionStep}-${(q.name || "").replace(/\W/g, "-")}`;
         const label = document.createElement("label");
         label.setAttribute("for", fieldId);
-        label.className = "block text-sm font-semibold tracking-wide text-slate-700";
+        label.className =
+          "block text-sm font-semibold tracking-wide text-slate-700 dark:text-slate-200";
         label.textContent = q.required ? `${q.label} *` : q.label;
         wrap.appendChild(label);
 
         let el;
+        let control = null;
 
         switch (q.type) {
           case "text":
-            el = document.createElement("input");
-            el.type = "text";
-            el.className = classListString(inputBaseClasses);
+            control = document.createElement("input");
+            control.type = "text";
+            control.className = classListString(inputBaseClasses);
             if (q.name === "name") {
-              el.placeholder = "First, Last";
-              el.addEventListener("blur", () => formatName(el));
+              control.placeholder = "First, Last";
+              control.addEventListener("blur", () => formatName(control));
             }
+            el = control;
             break;
 
           case "textarea":
-            el = document.createElement("textarea");
-            el.className = `${classListString(inputBaseClasses)} min-h-28 resize-y`;
+            control = document.createElement("textarea");
+            control.className = `${classListString(inputBaseClasses)} min-h-28 resize-y`;
+            el = control;
             break;
 
           case "select": {
-            el = document.createElement("select");
-            el.className = classListString(inputBaseClasses);
+            el = document.createElement("div");
+            el.className = "relative";
+            control = document.createElement("select");
+            control.className = `${classListString(inputBaseClasses)} pr-12 font-medium`;
             const selectPlaceholder = document.createElement("option");
             selectPlaceholder.value = "";
             selectPlaceholder.textContent = "Pick one…";
-            el.appendChild(selectPlaceholder);
+            control.appendChild(selectPlaceholder);
             q.options.forEach((opt) => {
               const option = document.createElement("option");
               option.value = opt;
               option.textContent = opt;
-              el.appendChild(option);
+              control.appendChild(option);
             });
+            el.appendChild(control);
+            el.insertAdjacentHTML(
+              "beforeend",
+              `<span class="pointer-events-none absolute inset-y-0 right-4 flex items-center text-slate-400 dark:text-slate-500">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.51a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+                </svg>
+              </span>`
+            );
             break;
           }
 
           case "radio": {
             el = document.createElement("div");
             el.className = "mt-3 grid gap-3 sm:grid-cols-2";
+            el.dataset.radioGroup = q.name;
 
             q.options.forEach((opt, index) => {
               const id = `${q.name}_${String(opt).replace(/\W/g, "")}_${index}`;
@@ -461,19 +520,19 @@
               radio.id = id;
               radio.name = q.name;
               radio.value = opt;
-              radio.className = "peer sr-only";
+              radio.className = "sr-only";
               if (q.required) radio.required = true;
+              radio.addEventListener("change", () => syncRadioGroup(q.name));
 
               const radioLabel = document.createElement("label");
               radioLabel.htmlFor = id;
+              radioLabel.dataset.radioCard = "true";
               radioLabel.className =
-                "flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm font-medium text-slate-700 shadow-sm transition duration-200 hover:border-skyhawk-300 hover:bg-skyhawk-50 peer-checked:border-skyhawk-500 peer-checked:bg-skyhawk-50 peer-checked:text-skyhawk-900 peer-focus:ring-4 peer-focus:ring-skyhawk-100";
+                "flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm font-medium text-slate-700 shadow-sm transition duration-200 hover:border-skyhawk-300 hover:bg-skyhawk-50 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200 dark:hover:border-skyhawk-400/60 dark:hover:bg-slate-800/80";
               radioLabel.innerHTML = `
                 <span>${opt}</span>
-                <span class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 bg-white text-transparent transition peer-checked:border-skyhawk-500 peer-checked:bg-skyhawk-500 peer-checked:text-white">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
-                    <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.04 7.1a1 1 0 0 1-1.42.004L3.29 8.85a1 1 0 0 1 1.42-1.408l4.25 4.288 6.33-6.384a1 1 0 0 1 1.414-.006Z" clip-rule="evenodd" />
-                  </svg>
+                <span data-radio-dot class="inline-flex h-5 w-5 items-center justify-center rounded-full border-2 border-slate-300 bg-white transition dark:border-slate-500 dark:bg-slate-950">
+                  <span data-radio-dot-inner class="h-2.5 w-2.5 scale-0 rounded-full bg-transparent transition"></span>
                 </span>
               `;
 
@@ -485,10 +544,10 @@
           }
         }
 
-        if (el.tagName !== "DIV") {
-          el.name = q.name;
-          el.id = fieldId;
-          if (q.required) el.required = true;
+        if (control) {
+          control.name = q.name;
+          control.id = fieldId;
+          if (q.required) control.required = true;
         }
 
         wrap.appendChild(el);
@@ -500,6 +559,33 @@
           form.querySelector(`[name="${name}"]:checked`)?.value ??
           form.querySelector(`[name="${name}"]`)?.value
         );
+      }
+
+      function syncRadioGroup(name) {
+        form.querySelectorAll(`input[name="${name}"]`).forEach((radio) => {
+          const label = form.querySelector(`label[for="${radio.id}"]`);
+          const dot = label?.querySelector("[data-radio-dot]");
+          const innerDot = label?.querySelector("[data-radio-dot-inner]");
+          if (!label || !dot || !innerDot) return;
+
+          label.classList.toggle("border-skyhawk-500", radio.checked);
+          label.classList.toggle("bg-skyhawk-50", radio.checked);
+          label.classList.toggle("text-skyhawk-900", radio.checked);
+          label.classList.toggle("ring-4", radio.checked);
+          label.classList.toggle("ring-skyhawk-100", radio.checked);
+          label.classList.toggle("dark:border-skyhawk-400", radio.checked);
+          label.classList.toggle("dark:bg-skyhawk-500/10", radio.checked);
+          label.classList.toggle("dark:text-skyhawk-100", radio.checked);
+          label.classList.toggle("dark:ring-skyhawk-500/20", radio.checked);
+
+          dot.classList.toggle("border-skyhawk-500", radio.checked);
+          dot.classList.toggle("bg-skyhawk-500", radio.checked);
+          dot.classList.toggle("dark:border-skyhawk-400", radio.checked);
+          dot.classList.toggle("dark:bg-skyhawk-400", radio.checked);
+          innerDot.classList.toggle("bg-white", radio.checked);
+          innerDot.classList.toggle("scale-100", radio.checked);
+          innerDot.classList.toggle("scale-0", !radio.checked);
+        });
       }
 
       function formatName(input) {
@@ -649,7 +735,7 @@
           }
         });
 
-        section.querySelectorAll("div.mt-3.grid").forEach((group) => {
+        section.querySelectorAll("[data-radio-group]").forEach((group) => {
           const firstRadio = group.querySelector("input[type='radio']");
           const name = firstRadio?.name;
           if (!name) return;
@@ -714,6 +800,10 @@
           }
         });
 
+        form.querySelectorAll("[data-radio-group]").forEach((group) => {
+          if (group.dataset.radioGroup) syncRadioGroup(group.dataset.radioGroup);
+        });
+
         stepHistory = [];
         showStep(1);
       }
@@ -742,6 +832,7 @@
             form.querySelectorAll(`[name="${q.name}"]`).forEach((radio) => {
               radio.checked = false;
             });
+            syncRadioGroup(q.name);
           } else {
             el.value = "";
           }

--- a/public/form.html
+++ b/public/form.html
@@ -187,6 +187,8 @@
           "items-center",
           "justify-center",
           "rounded-2xl",
+          "border",
+          "border-slate-900",
           "bg-slate-900",
           "px-5",
           "py-3",
@@ -204,7 +206,12 @@
           "focus:ring-slate-300",
           "disabled:cursor-not-allowed",
           "disabled:opacity-70",
-          "disabled:hover:translate-y-0"
+          "disabled:hover:translate-y-0",
+          "dark:border-skyhawk-300/35",
+          "dark:bg-skyhawk-400",
+          "dark:text-slate-950",
+          "dark:hover:bg-skyhawk-300",
+          "dark:focus:ring-skyhawk-500/30"
         ],
         secondary: [
           "inline-flex",
@@ -482,6 +489,16 @@
                   <span data-radio-dot-inner class="h-2.5 w-2.5 rounded-full bg-transparent opacity-0"></span>
                 </span>
               `;
+              radioLabel.addEventListener("click", (event) => {
+                event.preventDefault();
+                const changed = !radio.checked;
+                radio.checked = true;
+                syncRadioGroup(q.name);
+                saveFormData();
+                if (changed) {
+                  radio.dispatchEvent(new Event("change", { bubbles: true }));
+                }
+              });
 
               optionWrap.appendChild(radio);
               optionWrap.appendChild(radioLabel);
@@ -509,6 +526,7 @@
       }
 
       function syncRadioGroup(name) {
+        const isDarkMode = document.documentElement.classList.contains("dark");
         form.querySelectorAll(`input[name="${name}"]`).forEach((radio) => {
           const label = form.querySelector(`label[for="${radio.id}"]`);
           const dot = label?.querySelector("[data-radio-dot]");
@@ -526,10 +544,17 @@
           label.classList.toggle("dark:ring-skyhawk-500/20", radio.checked);
 
           dot.classList.toggle("border-skyhawk-500", radio.checked);
-          dot.classList.toggle("bg-skyhawk-500", radio.checked);
           dot.classList.toggle("dark:border-skyhawk-400", radio.checked);
-          dot.classList.toggle("dark:bg-skyhawk-400", radio.checked);
-          innerDot.style.backgroundColor = radio.checked ? "#ffffff" : "transparent";
+          dot.style.backgroundColor = radio.checked
+            ? isDarkMode
+              ? "rgba(14, 116, 144, 0.18)"
+              : "#ffffff"
+            : "";
+          innerDot.style.backgroundColor = radio.checked
+            ? isDarkMode
+              ? "#e2e8f0"
+              : "#5e84af"
+            : "transparent";
           innerDot.style.opacity = radio.checked ? "1" : "0";
         });
       }

--- a/public/form.html
+++ b/public/form.html
@@ -433,9 +433,10 @@
 
           case "select": {
             el = document.createElement("div");
-            el.className = "relative";
+            el.className =
+              "relative overflow-hidden rounded-[1.35rem] border-2 border-slate-200 bg-white shadow-[0_12px_32px_rgba(15,23,42,0.06)] dark:border-slate-700 dark:bg-slate-900";
             control = document.createElement("select");
-            control.className = `${classListString(inputBaseClasses)} pr-14 font-medium border-2 bg-white shadow-[0_12px_32px_rgba(15,23,42,0.06)] dark:bg-slate-900`;
+            control.className = `${classListString(inputBaseClasses)} mt-0 rounded-[1.25rem] border-0 bg-transparent pr-16 shadow-none`;
             const selectPlaceholder = document.createElement("option");
             selectPlaceholder.value = "";
             selectPlaceholder.textContent = "Pick one…";
@@ -449,8 +450,8 @@
             el.appendChild(control);
             el.insertAdjacentHTML(
               "beforeend",
-              `<span class="pointer-events-none absolute inset-y-0 right-3 flex items-center">
-                <span class="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-skyhawk-50 text-skyhawk-600 shadow-sm dark:bg-skyhawk-500/10 dark:text-skyhawk-200">
+              `<span class="pointer-events-none absolute inset-y-1.5 right-1.5 flex items-center">
+                <span class="inline-flex h-full min-h-11 w-11 items-center justify-center rounded-[1rem] border border-skyhawk-100 bg-skyhawk-50 text-skyhawk-600 shadow-sm dark:border-skyhawk-400/20 dark:bg-skyhawk-500/10 dark:text-skyhawk-200">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
                   <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.51a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
                 </svg>
@@ -492,10 +493,11 @@
               radioLabel.addEventListener("click", (event) => {
                 event.preventDefault();
                 const changed = !radio.checked;
-                radio.checked = true;
+                const shouldClear = radio.checked;
+                radio.checked = !shouldClear;
                 syncRadioGroup(q.name);
                 saveFormData();
-                if (changed) {
+                if (changed || shouldClear) {
                   radio.dispatchEvent(new Event("change", { bubbles: true }));
                 }
               });

--- a/public/form.html
+++ b/public/form.html
@@ -17,7 +17,6 @@
 
     <link rel="canonical" href="https://skyhawk-cap.org/calldown" />
 
-    <!-- Social Sharing (OG + Twitter) -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Home | Skyhawk Composite Squadron" />
     <meta
@@ -37,7 +36,6 @@
     />
     <meta property="twitter:image" content="https://skyhawk-cap.org/assets/images/webclip.png" />
 
-    <!-- Favicon & App Icons -->
     <link rel="apple-touch-icon" href="/assets/images/webclip.png" />
     <link rel="manifest" href="/assets/manifest.json" />
     <link rel="icon" href="/media/website/skyhawks_logo_CAP_transparent.png" />
@@ -46,285 +44,232 @@
       href="/media/website/skyhawks_logo_CAP_transparent.png"
       type="image/png"
     />
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        background-color: #f5f5f5;
-        padding: 20px;
-        color: #333;
-      }
-
-      form {
-        max-width: 900px;
-        margin: 0 auto;
-        background: #fff;
-        padding: 30px 35px;
-        border-radius: 12px;
-        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
-      }
-
-      section {
-        display: none;
-        animation: fadeIn 0.4s ease-in-out;
-      }
-
-      section.active {
-        display: block;
-      }
-
-      h2 {
-        font-size: 1.6rem;
-        margin-bottom: 20px;
-        border-bottom: 2px solid #ccc;
-        padding-bottom: 6px;
-        color: #555;
-      }
-
-      label {
-        display: block;
-        margin-bottom: 6px;
-        font-weight: 600;
-        font-size: 0.95rem;
-      }
-
-      input[type="text"],
-      select,
-      textarea {
-        width: 100%;
-        padding: 12px 14px;
-        margin-bottom: 20px;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        font-size: 1rem;
-        background: #f9f9f9;
-        transition:
-          border 0.2s,
-          box-shadow 0.2s;
-      }
-
-      input[type="text"]:focus,
-      select:focus,
-      textarea:focus {
-        border-color: #aaa;
-        box-shadow: 0 0 0 2px rgba(170, 170, 170, 0.2);
-        outline: none;
-      }
-
-      textarea {
-        resize: vertical;
-        min-height: 80px;
-      }
-
-      /* Radio buttons */
-      .radio-group {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 15px;
-        margin-bottom: 20px;
-      }
-
-      .radio-group input[type="radio"] {
-        display: none;
-      }
-
-      .radio-group label {
-        position: relative;
-        padding-left: 30px;
-        cursor: pointer;
-        user-select: none;
-        font-weight: 500;
-        font-size: 0.95rem;
-      }
-
-      .radio-group label::before {
-        content: "";
-        position: absolute;
-        left: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 20px;
-        height: 20px;
-        border-radius: 50%;
-        border: 2px solid #ccc;
-        background: #fff;
-        transition: all 0.2s;
-      }
-
-      .radio-group input[type="radio"]:checked + label::before {
-        background: #666;
-        border-color: #666;
-      }
-
-      button {
-        background-color: #666;
-        color: #fff;
-        padding: 14px 28px;
-        font-size: 1rem;
-        border: none;
-        border-radius: 8px;
-        cursor: pointer;
-        transition: background 0.3s ease;
-        margin-top: 10px;
-      }
-
-      button:hover {
-        background-color: #444;
-      }
-
-      @keyframes fadeIn {
-        from {
-          opacity: 0;
-          transform: translateY(10px);
-        }
-
-        to {
-          opacity: 1;
-          transform: translateY(0);
-        }
-      }
-
-      @media (max-width: 600px) {
-        .radio-group {
-          flex-direction: column;
-        }
-
-        button {
-          width: 100%;
-        }
-      }
-
-      /* Apply border-box globally so width includes padding and border */
-      *,
-      *::before,
-      *::after {
-        box-sizing: border-box;
-      }
-
-      /* Ensure all text fields, selects, and textareas are the same size */
-      input[type="text"],
-      select,
-      textarea {
-        width: 100%;
-        max-width: 100%;
-        padding: 12px 14px;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        font-size: 1rem;
-        background: #f9f9f9;
-      }
-      .form-nav {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-top: 20px;
-        gap: 10px;
-      }
-
-      .form-nav .right {
-        margin-left: auto;
-      }
-      .error-box {
-        background: #fdecea;
-        color: #b00020;
-        border: 1px solid #f5c2c7;
-        padding: 12px 14px;
-        border-radius: 8px;
-        margin-bottom: 20px;
-        font-size: 0.95rem;
-      }
-
-      .field-error {
-        border-color: #b00020 !important;
-        background: #fff5f5;
-      }
-      html.iframed,
-      html.iframed body {
-        background: transparent !important;
-      }
-
-      html.iframed form {
-        background: transparent !important; /* keep the form see-through */
-        box-shadow: none; /* remove shadow if you want */
-        border: 2px solid black; /* add a black border */
-        border-radius: 12px; /* optional: keep rounded corners */
-        padding: 30px 35px; /* keep padding inside the form */
-      }
-      button:disabled {
-        opacity: 0.7;
-        cursor: not-allowed;
-      }
-
-    </style>
-  </head>
-  <body>
-    <form id="cadetForm"><div id="formContainer"></div></form>
-
-<div id="closedMessage" style="
-  display: none;
-  max-width:900px;
-  margin:40px auto;
-  background:#ffffff;
-  padding:40px 45px;
-  border-radius:14px;
-  box-shadow:0 12px 25px rgba(0,0,0,0.08);
-  text-align:center;
-  border-top:5px solid #666;
-">
-  <h2 style="margin-bottom:10px; font-size:1.8rem; color:#333;">
-    Form Closed
-  </h2>
-
-  <p style="margin-bottom:15px; font-size:1.05rem; color:#555;">
-    This form is currently closed for the week.
-  </p>
-
-  <p style="margin-bottom:25px; font-size:1rem; color:#666;">
-    Please check back later to submit your response for the next meeting.
-  </p>
-
-  <p style="margin-bottom:-15px; font-size:1rem; color:#666;">
-    You are still welcome to attend the upcoming meeting; drill tests and other submissions must wait until next week.
-  </p>
-
-  <p style="margin-bottom:35px; font-size:1rem; color:#666;">
-    Please make sure to submit your response before the cutoff date next week to ensure your drill test is scheduled.
-  </p>
-
-  <div style="
-    display:inline-block;
-    background:#f5f5f5;
-    padding:12px 18px;
-    border-radius:8px;
-    font-size:0.95rem;
-    color:#444;
-    border:1px solid #e0e0e0;
-  ">
-    <strong>Reminder:</strong> All responses must be submitted before <strong>Sunday at 22:00</strong>.
-  </div>
-</div>
+    <script src="https://cdn.tailwindcss.com"></script>
     <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              skyhawk: {
+                50: "#f6f8fb",
+                100: "#eef2f8",
+                200: "#d9e3f0",
+                300: "#b8cadd",
+                400: "#8ca9c6",
+                500: "#5e84af",
+                600: "#456892",
+                700: "#344f73",
+                800: "#263a56",
+                900: "#17243a"
+              }
+            },
+            boxShadow: {
+              glow: "0 24px 80px rgba(23, 36, 58, 0.18)"
+            }
+          }
+        }
+      };
+    </script>
+  </head>
+  <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
+    <div class="relative isolate overflow-hidden">
+      <div
+        class="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(96,165,250,0.16),_transparent_30%),radial-gradient(circle_at_bottom_right,_rgba(14,165,233,0.14),_transparent_28%),linear-gradient(180deg,_#020617_0%,_#0f172a_45%,_#111827_100%)]"
+      ></div>
+      <div
+        class="absolute inset-x-0 top-0 -z-10 h-72 bg-gradient-to-b from-skyhawk-500/10 to-transparent blur-3xl"
+      ></div>
+
+      <main class="mx-auto flex min-h-screen max-w-6xl flex-col px-4 py-8 sm:px-6 lg:px-8 lg:py-12">
+        <div class="mx-auto mb-8 w-full max-w-4xl">
+          <div
+            class="rounded-[2rem] border border-white/10 bg-white/5 p-6 shadow-glow backdrop-blur-xl sm:p-8"
+          >
+            <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+              <div class="max-w-2xl">
+                <p
+                  class="mb-3 inline-flex items-center rounded-full border border-skyhawk-300/20 bg-skyhawk-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-skyhawk-100"
+                >
+                  Skyhawk Composite Squadron
+                </p>
+                <h1 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                  Weekly cadet response form
+                </h1>
+                <p class="mt-4 max-w-2xl text-sm leading-6 text-slate-300 sm:text-base">
+                  Confirm attendance, drill testing, and any notes for the next meeting using a
+                  cleaner, faster workflow built for mobile and desktop.
+                </p>
+              </div>
+
+              <div
+                class="grid gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-sm text-slate-300 sm:min-w-64"
+              >
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                    Weekly reminder
+                  </p>
+                  <p class="mt-1 font-medium text-slate-100">Submit before Sunday at 22:00</p>
+                </div>
+                <div class="h-px bg-white/10"></div>
+                <p class="leading-6 text-slate-400">
+                  Responses help staff prepare attendance, drill tests, and logistics before the
+                  next meeting.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <form
+          id="cadetForm"
+          class="mx-auto w-full max-w-4xl rounded-[2rem] border border-white/10 bg-white/95 p-5 text-slate-900 shadow-glow ring-1 ring-white/10 backdrop-blur sm:p-8 lg:p-10"
+        >
+          <div id="formContainer"></div>
+        </form>
+
+        <div
+          id="closedMessage"
+          class="mx-auto hidden w-full max-w-4xl rounded-[2rem] border border-amber-300/20 bg-white/95 p-6 text-center text-slate-900 shadow-glow ring-1 ring-amber-200/40 backdrop-blur sm:p-10"
+        >
+          <div
+            class="mx-auto inline-flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-100 text-amber-600 shadow-lg shadow-amber-200/60"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              class="h-8 w-8"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M6.75 3a.75.75 0 0 1 .75.75V6h9V3.75a.75.75 0 0 1 1.5 0V6h.75A2.25 2.25 0 0 1 21 8.25v9.5A2.25 2.25 0 0 1 18.75 20h-13.5A2.25 2.25 0 0 1 3 17.75v-9.5A2.25 2.25 0 0 1 5.25 6H6V3.75A.75.75 0 0 1 6.75 3Zm12.75 6.75H4.5v8a.75.75 0 0 0 .75.75h13.5a.75.75 0 0 0 .75-.75v-8Z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </div>
+          <h2 class="mt-6 text-3xl font-semibold tracking-tight text-slate-900">Form Closed</h2>
+          <p class="mt-3 text-base leading-7 text-slate-600 sm:text-lg">
+            This form is currently closed for the week.
+          </p>
+          <p class="mt-4 text-sm leading-7 text-slate-500 sm:text-base">
+            Please check back later to submit your response for the next meeting. You are still
+            welcome to attend the upcoming meeting; drill tests and other submissions must wait
+            until next week.
+          </p>
+          <p class="mt-4 text-sm leading-7 text-slate-500 sm:text-base">
+            Please make sure to submit your response before the cutoff date next week to ensure your
+            drill test is scheduled.
+          </p>
+          <div
+            class="mt-8 inline-flex rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner shadow-slate-200/70"
+          >
+            <span class="font-semibold text-slate-900">Reminder:</span>
+            <span class="ml-2">All responses must be submitted before Sunday at 22:00.</span>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <script>
+      const sectionClasses = {
+        base: ["hidden", "space-y-6", "duration-300"],
+        visible: ["block"]
+      };
+
+      const inputBaseClasses = [
+        "mt-2",
+        "block",
+        "w-full",
+        "rounded-2xl",
+        "border",
+        "border-slate-200",
+        "bg-white",
+        "px-4",
+        "py-3",
+        "text-base",
+        "text-slate-900",
+        "shadow-sm",
+        "outline-none",
+        "transition",
+        "duration-200",
+        "placeholder:text-slate-400",
+        "focus:border-skyhawk-500",
+        "focus:ring-4",
+        "focus:ring-skyhawk-100"
+      ];
+
+      const fieldWrapperClasses = ["space-y-2"];
+
+      const buttonClasses = {
+        primary: [
+          "inline-flex",
+          "items-center",
+          "justify-center",
+          "rounded-2xl",
+          "bg-slate-900",
+          "px-5",
+          "py-3",
+          "text-sm",
+          "font-semibold",
+          "text-white",
+          "shadow-lg",
+          "shadow-slate-900/20",
+          "transition",
+          "duration-200",
+          "hover:-translate-y-0.5",
+          "hover:bg-slate-800",
+          "focus:outline-none",
+          "focus:ring-4",
+          "focus:ring-slate-300",
+          "disabled:cursor-not-allowed",
+          "disabled:opacity-70",
+          "disabled:hover:translate-y-0"
+        ],
+        secondary: [
+          "inline-flex",
+          "items-center",
+          "justify-center",
+          "rounded-2xl",
+          "border",
+          "border-slate-200",
+          "bg-white",
+          "px-5",
+          "py-3",
+          "text-sm",
+          "font-semibold",
+          "text-slate-700",
+          "shadow-sm",
+          "transition",
+          "duration-200",
+          "hover:-translate-y-0.5",
+          "hover:border-slate-300",
+          "hover:bg-slate-50",
+          "focus:outline-none",
+          "focus:ring-4",
+          "focus:ring-slate-200"
+        ]
+      };
+
       if (window.self !== window.top) {
-        document.documentElement.classList.add("iframed");
+        document.body.className = "min-h-screen bg-transparent text-slate-100 antialiased";
+        const formShell = document.getElementById("cadetForm");
+        formShell.className =
+          "mx-auto w-full max-w-4xl rounded-[2rem] border border-white/20 bg-white/10 p-5 text-white shadow-none ring-1 ring-white/20 backdrop-blur-xl sm:p-8 lg:p-10";
       }
 
       function isFormClosed() {
         const now = new Date();
-
-        const day = now.getDay(); // 0 = Sunday, 1 = Monday, 2 = Tuesday
+        const day = now.getDay();
         const hours = now.getHours();
         const minutes = now.getMinutes();
-
         const currentMinutes = hours * 60 + minutes;
-
         const monday10am = 10 * 60;
         const tuesday10am = 10 * 60;
 
-        // Monday after 10:00 AM
         if (day === 1 && currentMinutes >= monday10am) {
           return true;
         }
 
-        // Tuesday before 10:00 AM
         if (day === 2 && currentMinutes < tuesday10am) {
           return true;
         }
@@ -334,8 +279,8 @@
 
       document.addEventListener("DOMContentLoaded", () => {
         if (isFormClosed()) {
-          document.getElementById("cadetForm").style.display = "none";
-          document.getElementById("closedMessage").style.display = "block";
+          document.getElementById("cadetForm").classList.add("hidden");
+          document.getElementById("closedMessage").classList.remove("hidden");
         }
       });
 
@@ -351,7 +296,6 @@
         localStorage.removeItem(COMPLETED_KEY);
       }
 
-      /* ---------- Load JSON ---------- */
       fetch("assets/json/form.json")
         .then((res) => res.json())
         .then((config) => {
@@ -361,48 +305,80 @@
         })
         .catch((err) => console.error("Failed to load form.json", err));
 
-      /* ---------- Render Form ---------- */
+      function classListString(values) {
+        return values.join(" ");
+      }
+
       function renderForm() {
         form.innerHTML = "";
 
-        formConfig.sections.forEach((section) => {
+        formConfig.sections.forEach((section, index) => {
           const sec = document.createElement("section");
           sec.dataset.step = section.step;
-          if (section.step === 1) sec.classList.add("active");
+          sec.className = classListString([
+            ...sectionClasses.base,
+            ...(section.step === 1 ? sectionClasses.visible : [])
+          ]);
 
+          const progressLabel = `Step ${index + 1} of ${formConfig.sections.length}`;
           const errorBoxId = `section-${section.step}-error`;
+          const progressWidth = `${((index + 1) / formConfig.sections.length) * 100}%`;
+
           sec.innerHTML = `
-      	  <h2>${section.title}</h2>
-      	  <div class="error-box" id="${errorBoxId}" style="display:none" role="alert"></div>
-      	`;
+            <div class="space-y-6">
+              <div class="space-y-4">
+                <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p class="text-xs font-semibold uppercase tracking-[0.24em] text-skyhawk-600">${progressLabel}</p>
+                    <h2 class="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">${section.title}</h2>
+                  </div>
+                  <div class="rounded-2xl border border-skyhawk-100 bg-skyhawk-50 px-4 py-3 text-sm text-skyhawk-700 shadow-sm">
+                    Complete each section before continuing.
+                  </div>
+                </div>
+                <div>
+                  <div class="h-2 w-full overflow-hidden rounded-full bg-slate-100">
+                    <div class="h-full rounded-full bg-gradient-to-r from-skyhawk-500 via-skyhawk-400 to-cyan-400" style="width: ${progressWidth}"></div>
+                  </div>
+                </div>
+              </div>
+              <div id="${errorBoxId}" class="hidden rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 shadow-sm" role="alert"></div>
+            </div>
+          `;
 
           section.questions.forEach((q) => {
             sec.appendChild(renderQuestion(q, section.step));
           });
 
           const nav = document.createElement("div");
-          nav.className = "form-nav";
+          nav.className =
+            "flex flex-col gap-3 border-t border-slate-200 pt-6 sm:flex-row sm:items-center sm:justify-between";
 
           if (section.step > 1) {
             const back = document.createElement("button");
             back.type = "button";
             back.textContent = "Back";
+            back.className = classListString(buttonClasses.secondary);
             back.onclick = prevStep;
             nav.appendChild(back);
+          } else {
+            const spacer = document.createElement("div");
+            spacer.className = "hidden sm:block";
+            nav.appendChild(spacer);
           }
 
           if (section.step < formConfig.sections.length) {
             const next = document.createElement("button");
             next.type = "button";
-            next.textContent = "Next";
-            next.className = "right";
+            next.textContent = "Continue";
+            next.className = `${classListString(buttonClasses.primary)} sm:ml-auto`;
             next.onclick = nextStep;
             nav.appendChild(next);
           } else {
             const submit = document.createElement("button");
             submit.type = "submit";
-            submit.textContent = "Submit";
-            submit.className = "right";
+            submit.textContent = "Submit response";
+            submit.className = `${classListString(buttonClasses.primary)} sm:ml-auto`;
             nav.appendChild(submit);
           }
 
@@ -410,23 +386,32 @@
           form.appendChild(sec);
         });
 
-        // confirmation section
         const done = document.createElement("section");
         done.dataset.step = formConfig.sections.length + 1;
+        done.className = classListString(sectionClasses.base);
         done.innerHTML = `
-          <h2>Submission Complete</h2>
-          <p id="confirmationMessage"></p>
+          <div class="rounded-[2rem] border border-emerald-200 bg-emerald-50 p-6 shadow-sm sm:p-8">
+            <div class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500 text-white shadow-lg shadow-emerald-200">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-7 w-7">
+                <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-2.53a.75.75 0 1 0-1.22-.88l-3.236 4.486-1.387-1.387a.75.75 0 0 0-1.06 1.06l2.012 2.013a.75.75 0 0 0 1.14-.09l3.75-5.202Z" clip-rule="evenodd" />
+              </svg>
+            </div>
+            <h2 class="mt-5 text-3xl font-semibold tracking-tight text-emerald-950">Submission complete</h2>
+            <p id="confirmationMessage" class="mt-3 max-w-2xl text-base leading-7 text-emerald-900"></p>
+          </div>
         `;
         form.appendChild(done);
       }
 
       function renderQuestion(q, sectionStep) {
         const wrap = document.createElement("div");
-        const fieldId = `field-${sectionStep}-${(q.name || "").replace(/\W/g, "-")}`;
+        wrap.className = classListString(fieldWrapperClasses);
 
+        const fieldId = `field-${sectionStep}-${(q.name || "").replace(/\W/g, "-")}`;
         const label = document.createElement("label");
         label.setAttribute("for", fieldId);
-        label.textContent = q.label;
+        label.className = "block text-sm font-semibold tracking-wide text-slate-700";
+        label.textContent = q.required ? `${q.label} *` : q.label;
         wrap.appendChild(label);
 
         let el;
@@ -435,21 +420,21 @@
           case "text":
             el = document.createElement("input");
             el.type = "text";
-
-            // ONLY apply to the name field
+            el.className = classListString(inputBaseClasses);
             if (q.name === "name") {
               el.placeholder = "First, Last";
               el.addEventListener("blur", () => formatName(el));
             }
-
             break;
 
           case "textarea":
             el = document.createElement("textarea");
+            el.className = `${classListString(inputBaseClasses)} min-h-28 resize-y`;
             break;
 
           case "select": {
             el = document.createElement("select");
+            el.className = classListString(inputBaseClasses);
             const selectPlaceholder = document.createElement("option");
             selectPlaceholder.value = "";
             selectPlaceholder.textContent = "Pick one…";
@@ -465,20 +450,36 @@
 
           case "radio": {
             el = document.createElement("div");
-            el.className = "radio-group";
+            el.className = "mt-3 grid gap-3 sm:grid-cols-2";
 
-            q.options.forEach((opt) => {
-              const id = `${q.name}_${String(opt).replace(/\W/g, "")}`;
+            q.options.forEach((opt, index) => {
+              const id = `${q.name}_${String(opt).replace(/\W/g, "")}_${index}`;
+              const optionWrap = document.createElement("div");
+
               const radio = document.createElement("input");
               radio.type = "radio";
               radio.id = id;
               radio.name = q.name;
               radio.value = opt;
+              radio.className = "peer sr-only";
+              if (q.required) radio.required = true;
+
               const radioLabel = document.createElement("label");
               radioLabel.htmlFor = id;
-              radioLabel.textContent = opt;
-              el.appendChild(radio);
-              el.appendChild(radioLabel);
+              radioLabel.className =
+                "flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm font-medium text-slate-700 shadow-sm transition duration-200 hover:border-skyhawk-300 hover:bg-skyhawk-50 peer-checked:border-skyhawk-500 peer-checked:bg-skyhawk-50 peer-checked:text-skyhawk-900 peer-focus:ring-4 peer-focus:ring-skyhawk-100";
+              radioLabel.innerHTML = `
+                <span>${opt}</span>
+                <span class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 bg-white text-transparent transition peer-checked:border-skyhawk-500 peer-checked:bg-skyhawk-500 peer-checked:text-white">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
+                    <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.04 7.1a1 1 0 0 1-1.42.004L3.29 8.85a1 1 0 0 1 1.42-1.408l4.25 4.288 6.33-6.384a1 1 0 0 1 1.414-.006Z" clip-rule="evenodd" />
+                  </svg>
+                </span>
+              `;
+
+              optionWrap.appendChild(radio);
+              optionWrap.appendChild(radioLabel);
+              el.appendChild(optionWrap);
             });
             break;
           }
@@ -489,12 +490,11 @@
           el.id = fieldId;
           if (q.required) el.required = true;
         }
-        // Radio group: individual inputs already have id/label[for] from render
 
         wrap.appendChild(el);
         return wrap;
       }
-      /* ---------- Navigation ---------- */
+
       function getFieldValue(name) {
         return (
           form.querySelector(`[name="${name}"]:checked`)?.value ??
@@ -506,10 +506,7 @@
         let value = input.value.trim();
         if (!value) return;
 
-        // Remove extra spaces
         value = value.replace(/\s+/g, " ");
-
-        // Normalize commas (remove spaces around)
         value = value.replace(/\s*,\s*/g, ",");
 
         let first = "";
@@ -518,11 +515,9 @@
         if (value.includes(",")) {
           const parts = value.split(",");
           if (parts.length === 2) {
-            // Check if it’s already "First, Last"
             const firstCap = parts[0].charAt(0).toUpperCase() + parts[0].slice(1).toLowerCase();
             const lastCap = parts[1].charAt(0).toUpperCase() + parts[1].slice(1).toLowerCase();
-            // If first part looks like a last name, swap
-            if (firstCap === parts[1].charAt(0).toUpperCase() + parts[1].slice(1).toLowerCase()) {
+            if (firstCap === lastCap) {
               first = parts[1].trim();
               last = parts[0].trim();
             } else {
@@ -538,7 +533,6 @@
           }
         }
 
-        // Capitalize properly
         const cap = (str) =>
           str
             .toLowerCase()
@@ -549,14 +543,13 @@
         first = cap(first);
         last = cap(last);
 
-        // ✅ Only set if both parts exist
         if (first && last) {
           input.value = `${first}, ${last}`;
         }
       }
 
       function resolveNextStep() {
-        const section = formConfig.sections.find(s => s.step === currentStep);
+        const section = formConfig.sections.find((s) => s.step === currentStep);
         if (!section?.navigation) return currentStep + 1;
 
         for (const rule of section.navigation) {
@@ -570,8 +563,16 @@
       }
 
       function showStep(step) {
-        document.querySelectorAll("section").forEach(s => s.classList.remove("active"));
-        document.querySelector(`section[data-step="${step}"]`)?.classList.add("active");
+        document.querySelectorAll("section").forEach((section) => {
+          section.classList.add(...sectionClasses.base);
+          section.classList.remove(...sectionClasses.visible);
+        });
+
+        const activeSection = document.querySelector(`section[data-step="${step}"]`);
+        if (activeSection) {
+          activeSection.classList.remove(...sectionClasses.base);
+          activeSection.classList.add(...sectionClasses.visible, "space-y-6");
+        }
 
         currentStep = step;
         saveFormData();
@@ -601,101 +602,118 @@
         }
       }
 
+      function setFieldErrorState(field, hasError) {
+        if (!field) return;
+        field.classList.toggle("border-rose-300", hasError);
+        field.classList.toggle("bg-rose-50", hasError);
+        field.classList.toggle("ring-4", hasError);
+        field.classList.toggle("ring-rose-100", hasError);
+      }
+
       function validateCurrentSection() {
         const section = document.querySelector(`section[data-step="${currentStep}"]`);
-        const errorBox = section.querySelector(".error-box");
+        const errorBox = section.querySelector("[role='alert']");
         let valid = true;
 
-        errorBox.style.display = "none";
+        errorBox.classList.add("hidden");
         errorBox.textContent = "";
 
-        // clear old field errors
-        section.querySelectorAll(".field-error").forEach((el) => {
-          el.classList.remove("field-error");
-          el.removeAttribute("aria-invalid");
-          el.removeAttribute("aria-describedby");
-        });
         section
           .querySelectorAll("input[aria-invalid], select[aria-invalid], textarea[aria-invalid]")
           .forEach((el) => {
             el.removeAttribute("aria-invalid");
             el.removeAttribute("aria-describedby");
+            setFieldErrorState(el, false);
           });
 
-        // validate inputs
+        section.querySelectorAll(".radio-option-error").forEach((label) => {
+          label.classList.remove(
+            "radio-option-error",
+            "border-rose-300",
+            "bg-rose-50",
+            "text-rose-700"
+          );
+        });
+
         const requiredFields = section.querySelectorAll(
-          "input[required], textarea[required], select[required]"
+          "input[required]:not([type='radio']), textarea[required], select[required]"
         );
 
         const errorBoxId = errorBox.id || `section-${currentStep}-error`;
         requiredFields.forEach((field) => {
           if (!field.value.trim()) {
-            field.classList.add("field-error");
+            setFieldErrorState(field, true);
             field.setAttribute("aria-invalid", "true");
             field.setAttribute("aria-describedby", errorBoxId);
             valid = false;
-          } else {
-            field.removeAttribute("aria-invalid");
-            field.removeAttribute("aria-describedby");
           }
         });
 
-        // validate radio groups
-        section.querySelectorAll(".radio-group").forEach((group) => {
-          const name = group.querySelector("input")?.name;
+        section.querySelectorAll("div.mt-3.grid").forEach((group) => {
+          const firstRadio = group.querySelector("input[type='radio']");
+          const name = firstRadio?.name;
           if (!name) return;
 
+          const radioSet = section.querySelectorAll(`input[name="${name}"]`);
+          const isRequired = Array.from(radioSet).some((radio) => radio.required);
+          if (!isRequired) return;
+
           if (!section.querySelector(`input[name="${name}"]:checked`)) {
-            group.querySelectorAll("label").forEach((l) => l.classList.add("field-error"));
-            const firstRadio = group.querySelector("input");
+            group.querySelectorAll("label").forEach((label) => {
+              label.classList.add(
+                "radio-option-error",
+                "border-rose-300",
+                "bg-rose-50",
+                "text-rose-700"
+              );
+            });
             if (firstRadio) {
               firstRadio.setAttribute("aria-invalid", "true");
               firstRadio.setAttribute("aria-describedby", errorBoxId);
             }
             valid = false;
           } else {
-            group.querySelectorAll("input").forEach((inp) => {
-              inp.removeAttribute("aria-invalid");
-              inp.removeAttribute("aria-describedby");
+            radioSet.forEach((radio) => {
+              radio.removeAttribute("aria-invalid");
+              radio.removeAttribute("aria-describedby");
             });
           }
         });
 
         if (!valid) {
           errorBox.textContent = "Please complete all required fields before continuing.";
-          errorBox.style.display = "block";
+          errorBox.classList.remove("hidden");
         }
 
         return valid;
       }
 
-      /* ---------- Storage ---------- */
       function saveFormData() {
         if (localStorage.getItem(COMPLETED_KEY) === "true") return;
 
         const data = {};
-        new FormData(form).forEach((v, k) => (data[k] = v));
+        new FormData(form).forEach((value, key) => {
+          data[key] = value;
+        });
         localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
       }
 
       function loadFormData() {
         const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
 
-        // restore field values ONLY
-        Object.entries(saved).forEach(([k, v]) => {
-          if (k === "_step") return; // ❌ ignore saved step
+        Object.entries(saved).forEach(([key, value]) => {
+          if (key === "_step") return;
 
-          const el = form.querySelector(`[name="${k}"]`);
+          const el = form.querySelector(`[name="${key}"]`);
           if (!el) return;
 
           if (el.type === "radio") {
-            form.querySelector(`[name="${k}"][value="${v}"]`)?.click();
+            form.querySelector(`[name="${key}"][value="${value}"]`)?.click();
           } else {
-            el.value = v;
+            el.value = value;
           }
         });
 
-        // ✅ ALWAYS start at step 1 on reload
         stepHistory = [];
         showStep(1);
       }
@@ -711,16 +729,19 @@
 
         stepHistory = [1];
       });
+
       function clearSection(step) {
-        const section = formConfig.sections.find(s => s.step === step);
+        const section = formConfig.sections.find((s) => s.step === step);
         if (!section) return;
 
-        section.questions.forEach(q => {
+        section.questions.forEach((q) => {
           const el = form[q.name];
           if (!el) return;
 
           if (el.type === "radio") {
-            form.querySelectorAll(`[name="${q.name}"]`).forEach(r => r.checked = false);
+            form.querySelectorAll(`[name="${q.name}"]`).forEach((radio) => {
+              radio.checked = false;
+            });
           } else {
             el.value = "";
           }
@@ -738,7 +759,7 @@
       form.addEventListener("submit", (e) => {
         e.preventDefault();
 
-        if (submitting) return; // stop double submits
+        if (submitting) return;
         submitting = true;
 
         const submitBtn = form.querySelector('button[type="submit"]');
@@ -770,29 +791,27 @@
           },
           body: params
         })
-        .then(() => {
-          document.getElementById("confirmationMessage").textContent =
-            getAttend() === "Yes"
-              ? formConfig.confirmationMessages.attendYes
-              : formConfig.confirmationMessages.attendNo;
+          .then(() => {
+            document.getElementById("confirmationMessage").textContent =
+              getAttend() === "Yes"
+                ? formConfig.confirmationMessages.attendYes
+                : formConfig.confirmationMessages.attendNo;
 
-          localStorage.setItem(COMPLETED_KEY, "true");
-          localStorage.removeItem(STORAGE_KEY);
+            localStorage.setItem(COMPLETED_KEY, "true");
+            localStorage.removeItem(STORAGE_KEY);
 
-          form.reset();
-          showStep(4);
-        })
-        .catch(() => {
-          submitting = false;
-          if (submitBtn) {
-            submitBtn.disabled = false;
-            submitBtn.textContent = "Submit";
-          }
-          alert("Submission failed. Please try again.");
-        });
+            form.reset();
+            showStep(4);
+          })
+          .catch(() => {
+            submitting = false;
+            if (submitBtn) {
+              submitBtn.disabled = false;
+              submitBtn.textContent = "Submit response";
+            }
+            alert("Submission failed. Please try again.");
+          });
       });
-
-
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace legacy inline CSS with Tailwind utility classes to make the form easier to style and maintain.
- Modernize the visual hierarchy and mobile responsiveness for a cleaner, more professional cadet response experience.
- Preserve the existing multi-step logic, validation, localStorage behavior, and Google Form submission while improving UX.

### Description
- Removed the old embedded `<style>` block and added the Tailwind CDN with a small `tailwind.config` extension for a custom `skyhawk` palette and `glow` shadow.
- Rebuilt the page layout and hero using Tailwind utilities and a dark gradient backdrop, and replaced the plain form shell with a rounded, card-style form container.
- Reworked form rendering JavaScript to emit Tailwind utility classes for inputs, textareas, selects, radio option cards, progress bars, navigation buttons, closed-state UI, and confirmation state while keeping existing behavior intact.
- Updated client-side validation styling to toggle Tailwind error classes and switched section visibility handling to class-based show/hide for smoother transitions.

### Testing
- Ran `npx prettier --write public/form.html` and `npx prettier --check public/form.html` which passed and ensured consistent formatting.
- Verified the output file no longer contains the old `<style>` block and does load Tailwind via CDN using a simple Python presence check which returned `style tag present: False` and `tailwind script present: True`.
- Manual sanity verification of in-file changes (diff/stat) to confirm form logic, Google Form submission flow, and localStorage usage were preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2fdd5b4083298eef94de111d6633)